### PR TITLE
Resolve issues in common breaking michigan, arizona

### DIFF
--- a/common/src/common.py
+++ b/common/src/common.py
@@ -21,13 +21,13 @@ def key_namer(args, kwargs):
 work_dir = dir_path(__file__) + '/../../cache/'
 
 @checkpoint(key=key_namer, work_dir=work_dir)
-def cache_request(url, method='GET', data={}, wait=None, is_binary=False):
+def cache_request(url, method='GET', data={}, wait=None, is_binary=False, verify=True):
   if wait is not None:
     time.sleep(wait)
   if data:
-    response = requests.request(method, url, data=data, stream=is_binary)
+    response = requests.request(method, url, data=data, stream=is_binary, verify=verify)
   else:
-    response = requests.request(method, url, stream=is_binary)
+    response = requests.request(method, url, stream=is_binary, verify=verify)
 
   if is_binary:
     return response.content

--- a/common/src/common.py
+++ b/common/src/common.py
@@ -80,6 +80,9 @@ def normalize_state(data):
   for datum in data:
     for key in datum.keys():
       if isinstance(datum[key], list):
-        datum[key] = sorted(set(datum[key]))
+        try:
+          datum[key] = sorted(set(datum[key]))
+        except TypeError:
+          pass #not hashable
   data.sort(key=lambda x: x.get('locale',''))
   return data


### PR DESCRIPTION
Michigan has an issue with SSL certs that I was able to resolve by adding a verify parameter to `cache_request` / `requests.request`. It allows me to pass a corrected cert chain since requests won't go download intermediate certs on its own (unlike a browser).

Sorry I wasn't more clear on the need for pr #21 . There's an error with arizona after we generalized `normalize_state `with `isinstance`, so some change is required. If you don't like the try/except, alternate options include:

1. modifying arizona to not [store other_officials as a list of dictionaries](https://github.com/mail-my-ballot/elections-officials/blob/580a242be586bdd1e1963d0b734dda7d60269f10/states/arizona/main.py#L38)
2. checking every item in the list with `isinstance({}, collections.Hashable)`. I don't like this option because it requires looping through each item; seems very inefficient

If you prefer option 1, I can remove the try/except and update arizona on a separate branch... I still need the `verify` change for michigan.