### PR TITLE
add cache_selenium for massachusetts

### DIFF
--- a/common/src/common.py
+++ b/common/src/common.py
@@ -39,7 +39,7 @@ def cache_request(url, method='GET', data={}, wait=None, is_binary=False, verify
     return response.text
     
 @checkpoint(key=selenium_key_namer, work_dir=work_dir)
-def cache_selenium(url, wait=None, selenium=True):
+def cache_selenium(url, wait=None):
   if wait is not None:
     time.sleep(wait)
   options = webdriver.ChromeOptions()

--- a/common/src/common.py
+++ b/common/src/common.py
@@ -37,7 +37,7 @@ def cache_request(url, method='GET', data={}, wait=None, is_binary=False, verify
     return response.content
   else:
     return response.text
-    
+
 @checkpoint(key=selenium_key_namer, work_dir=work_dir)
 def cache_selenium(url, wait=None):
   if wait is not None:


### PR DESCRIPTION
Allows using a shared cache for js obfuscated pages, similarly to cache_request.

Some states use js obfuscation for more than just e-mail -- e.g., the entire Massachusetts page is obfuscated.