### PR TITLE
fix exit code for ci tests, remove lintwarn

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -62,9 +62,7 @@ confidence=
 # --disable=W".
 disable=missing-module-docstring,
         missing-class-docstring,
-        missing-function-docstring,
-		duplicate-code,
-		invalid-name
+        missing-function-docstring
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,6 @@ jupyter:
 	
 lint:
 	source venv/bin/activate && inv lint
-	
-lintwarn:
-	source venv/bin/activate && inv lintwarn
 
 test:
 	source venv/bin/activate && inv test

--- a/src/states/alaska/main.py
+++ b/src/states/alaska/main.py
@@ -32,8 +32,7 @@ def fetch_data():
       email_address = email['href'].replace('mailto:', '')
     data['emails'].append(email_address)
 
-  for p in soup.find_all('p'):
-    text = p.text
+  for text in [p.text for p in soup.find_all('p')]:
     if 'Fax' in text:
       data['faxes'].append(extract_phone_number(text))
     elif 'Phone' in text or 'Toll-Free' in text:

--- a/src/states/arizona/main.py
+++ b/src/states/arizona/main.py
@@ -2,18 +2,15 @@ import re
 from bs4 import BeautifulSoup
 from common import cache_request, decode_email
 
-re_recorder_str = r'(?P<recorder>\S.*\S)\s*\n.*County Recorder\s*Physical:\s*(?P<physical>\S.*\S)\s*'
-re_recorder_str += r'Mailing:\s*(?P<mailing>\S.*\S)\s*(?P<city_state_zip>\S.*\d{5}(-\d+)?)'
-re_recorder = re.compile(re_recorder_str, flags=re.MULTILINE)
-
-re_director_str = r'(?P<director>\S.*\S)\s*\n.*County\s*\w*\s*Director.*\n\s*Physical:\s*(?P<physical>\S.*\S)\s*'
-re_director_str += r'Mailing:\s*(?P<mailing>\S.*\S)\s*(?P<city_state_zip>\S.*\d{5}(-\d+)?)\s'
-re_director = re.compile(re_director_str, flags=re.MULTILINE)
-
-re_director2_str = r'(?P<director>\S.*\S)\s*\n.*County\s*\w*\s*Director.*\n\s*'
-re_director2_str += r'(?P<full_address>\S*(.|\n)*?\d{5}(-\d+)?)\s'
-re_director2 = re.compile(re_director2_str, flags=re.MULTILINE)
-
+re_recorder = re.compile(r'(?P<recorder>\S.*\S)\s*\n.*County Recorder\s*Physical:\s*(?P<physical>\S.*\S)\s*'
+                         + r'Mailing:\s*(?P<mailing>\S.*\S)\s*(?P<city_state_zip>\S.*\d{5}(-\d+)?)',
+                         flags=re.MULTILINE)
+re_director = re.compile(r'(?P<director>\S.*\S)\s*\n.*County\s*\w*\s*Director.*\n\s*Physical:\s*(?P<physical>\S.*\S)\s*'
+                         + r'Mailing:\s*(?P<mailing>\S.*\S)\s*(?P<city_state_zip>\S.*\d{5}(-\d+)?)\s',
+                         flags=re.MULTILINE)
+re_director2 = re.compile(r'(?P<director>\S.*\S)\s*\n.*County\s*\w*\s*Director.*\n\s*'
+                          + r'(?P<full_address>\S*(.|\n)*?\d{5}(-\d+)?)\s',
+                          flags=re.MULTILINE)
 re_extra_spaces = re.compile(r'[^\S\n]+')
 re_recorder2 = re.compile(r'(?P<recorder>\S.*\S)\s*\n.*County Recorder\s*(?P<full_address>\S(.|\n)*?\d{5}(-\d+)?)\s',
                           flags=re.MULTILINE)

--- a/src/states/georgia/main.py
+++ b/src/states/georgia/main.py
@@ -20,14 +20,14 @@ def parse_contact_line(line):
     return {}
   parsed = line.split(':')
   if len(parsed) == 2:
-    k, v = parsed
-    return {k.strip(): v.strip()}
+    k, val = parsed
+    return {k.strip(): val.strip()}
   return {}
 
 
-def parse_contact(h4):
-  title = h4.text
-  line1 = h4.next_element.next_element
+def parse_contact(h4_elem):
+  title = h4_elem.text
+  line1 = h4_elem.next_element.next_element
   line2 = line1.next_element.next_element
   if title.endswith('Address:'):
     return {

--- a/src/states/nebraska/main.py
+++ b/src/states/nebraska/main.py
@@ -8,20 +8,20 @@ BASE_URL = 'https://sos.nebraska.gov/elections/election-officials-contact-inform
 
 def get_key_text(_iter):
   while True:
-    el = next(_iter)
-    if isinstance(el, Tag) and el.name == 'strong':
-      return el.text.split(':')[0]
+    elem = next(_iter)
+    if isinstance(elem, Tag) and elem.name == 'strong':
+      return elem.text.split(':')[0]
 
 
 def get_val_text(_iter):
   text = ''
   while True:
-    el = next(_iter)
-    if isinstance(el, NavigableString):
-      text += el.strip()
-    if isinstance(el, Tag) and el.name == 'a':
-      text += el.text.strip()
-    if (isinstance(el, Tag) and el.name == 'br'):
+    elem = next(_iter)
+    if isinstance(elem, NavigableString):
+      text += elem.strip()
+    if isinstance(elem, Tag) and elem.name == 'a':
+      text += elem.text.strip()
+    if (isinstance(elem, Tag) and elem.name == 'br'):
       return text
 
 
@@ -69,7 +69,6 @@ def fetch_data():
   soup = BeautifulSoup(text, 'lxml')
 
   counties = soup.select('div.field-items>div.field-item div.col-sm-6')
-  print(len(counties))
   data = [parse_county(county) for county in counties]
   assert len(data) == 93
 

--- a/src/states/new_york/desktop.ini
+++ b/src/states/new_york/desktop.ini
@@ -1,2 +1,0 @@
-[LocalizedFileNames]
-new_york.py=@new_york.py,0

--- a/src/states/new_york/main.py
+++ b/src/states/new_york/main.py
@@ -2,9 +2,9 @@ import re
 from bs4 import BeautifulSoup
 from common import cache_request
 
-re_locale_address_str = r'(?P<locale>\S([^\S\n]|\w)*\s*County)\s*Board of Elections\s*'
-re_locale_address_str += r'(?P<address>\S.*\d{5}(-\d+)?)\s*'
-re_locale_address = re.compile(re_locale_address_str, flags=re.MULTILINE + re.DOTALL)
+re_locale_address = re.compile(r'(?P<locale>\S([^\S\n]|\w)*\s*County)\s*Board of Elections\s*'
+                               + r'(?P<address>\S.*\d{5}(-\d+)?)\s*',
+                               flags=re.MULTILINE + re.DOTALL)
 
 re_extra_spaces = re.compile(r'[^\S\n]+')
 re_phone_line = re.compile(r'Phone:\s*(.*)\n')

--- a/src/tasks.py
+++ b/src/tasks.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import pkgutil
 import importlib
 import unittest
@@ -29,4 +30,6 @@ def collect(c, state):  # pylint: disable=unused-argument,invalid-name
 @task
 def test(c):  # pylint: disable=unused-argument,invalid-name
   suite = unittest.TestLoader().discover('tests')
-  unittest.TextTestRunner().run(suite)
+  result = unittest.TextTestRunner().run(suite)
+  if not result.wasSuccessful():
+    sys.exit(1)

--- a/src/tests/test_michigan_fips.py
+++ b/src/tests/test_michigan_fips.py
@@ -8,8 +8,8 @@ from common import dir_path, public_dir
 def get_arcgis_fipscode():
   # The following file is the Michigan ARCGIS data and unlikely to change with time
   # https://gis-michigan.opendata.arcgis.com/datasets/minor-civil-divisions-cities-townships-v17a/data?geometry=-167.515%2C43.121%2C169.985%2C84.204
-  with open(os.path.join(dir_path(__file__), 'data', 'Minor_Civil_Divisions.csv')) as fh:
-    rows = list(csv.reader(fh))
+  with open(os.path.join(dir_path(__file__), 'data', 'Minor_Civil_Divisions.csv')) as csv_file:
+    rows = list(csv.reader(csv_file))
     header = rows[0]
     rows = rows[1:]
     label_idx = header.index('FIPSCODE')
@@ -18,8 +18,8 @@ def get_arcgis_fipscode():
 
 def get_data_fipscode():
   file_ = os.path.join(public_dir, 'michigan.json')
-  with open(file_) as fh:
-    rows = json.load(fh)
+  with open(file_) as json_file:
+    rows = json.load(json_file)
     return sorted([row['fipscode'] for row in rows])
 
 

--- a/src/tests/test_public.py
+++ b/src/tests/test_public.py
@@ -11,21 +11,21 @@ def publics():
 
 
 class TestPublic(unittest.TestCase):
-  def assert_nonempty_string(self, x, allow_none=True, regex=None, stripped=True, titled=True):  # pylint: disable=too-many-arguments
-    if allow_none and x is None:
+  def assert_nonempty_string(self, val, allow_none=True, regex=None, stripped=True, titled=True):  # pylint: disable=too-many-arguments
+    if allow_none and val is None:
       return
-    self.assertIsInstance(x, str)
-    self.assertIsNot(x, '')
+    self.assertIsInstance(val, str)
+    self.assertIsNot(val, '')
 
     if stripped:
-      self.assertEqual(x, x.strip())
+      self.assertEqual(val, val.strip())
 
     if titled:
-      self.assertNotEqual(x, x.lower())
-      self.assertNotEqual(x, x.upper())
+      self.assertNotEqual(val, val.lower())
+      self.assertNotEqual(val, val.upper())
 
     if regex:
-      self.assertTrue(regex.search(x))
+      self.assertTrue(regex.search(val))
 
   def assert_string_list(self, list_, allow_none=True, regex=None):
     if allow_none and list_ is None:
@@ -33,38 +33,38 @@ class TestPublic(unittest.TestCase):
 
     self.assertIsInstance(list_, list)
     self.assertEqual(len(list_), len(set(list_)))
-    for x in list_:
-      self.assertIsInstance(x, str)
+    for val in list_:
+      self.assertIsInstance(val, str)
 
       if regex:
-        self.assertTrue(regex.search(x), f'"{x}" does not match regex "{regex.pattern}"')
+        self.assertTrue(regex.search(val), f'"{val}" does not match regex "{regex.pattern}"')
       else:
-        self.assertTrue(x)
+        self.assertTrue(val)
 
   @parameterized.expand(publics)
-  def test_state(self, public_file):
-    with open(public_file) as fh:
-      data = json.load(fh)
+  def test_state(self, public_filename):
+    with open(public_filename) as public_file:
+      data = json.load(public_file)
 
     self.assertIsInstance(data, list)
-    if 'alaska' in public_file:
+    if 'alaska' in public_filename:
       self.assertEqual(len(data), 1)
     else:
       self.assertGreater(len(data), 10)
 
-    for d in data:
-      self.assert_nonempty_string(d.get('locale'), allow_none=False)
-      self.assert_nonempty_string(d.get('official'), titled=False)
+    for datum in data:
+      self.assert_nonempty_string(datum.get('locale'), allow_none=False)
+      self.assert_nonempty_string(datum.get('official'), titled=False)
 
-      self.assert_nonempty_string(d.get('city'))
-      self.assert_nonempty_string(d.get('county'), regex=re.compile(' County$'))
+      self.assert_nonempty_string(datum.get('city'))
+      self.assert_nonempty_string(datum.get('county'), regex=re.compile(' County$'))
 
       self.assert_string_list(
-        d.get('emails'),
+        datum.get('emails'),
         regex=re.compile(r'^([a-zA-Z0-9_\-\.]+)@([a-zA-Z0-9_\-\.]+)\.([a-zA-Z]{2,5})$')
       )
       self.assert_string_list(
-        d.get('faxes'),
+        datum.get('faxes'),
         regex=re.compile(r'^\D*1?\D*\d{3}\D*\d{3}\D*\d{4}\D*$')
       )
 

--- a/tasks.py
+++ b/tasks.py
@@ -15,15 +15,5 @@ def lint(c):  # pylint: disable=invalid-name
 
 
 @task
-def lintwarn(c):  # pylint: disable=invalid-name
-  '''
-  This is temporary and used to identify cases where certain warning flags are showing up
-  Remove me when I no longer generate warnings.
-  '''
-  disable = "--disable=missing-module-docstring,missing-class-docstring,missing-function-docstring"
-  c.run(f"{VENV_ACTIVATE} && pylint tasks.py src --rcfile=.pylintrc --exit-zero --enable=all {disable} --reports=y")
-
-
-@task
 def test(c):  # pylint: disable=invalid-name
   c.run(f"{VENV_ACTIVATE} && cd src && inv test")

--- a/tasks.py
+++ b/tasks.py
@@ -5,17 +5,17 @@ VENV_ACTIVATE = "venv\\Scripts\\activate" if os.name == 'nt' else ". ./venv/bin/
 
 
 @task
-def collect(c, state):
+def collect(c, state):  # pylint: disable=invalid-name
   c.run(f"{VENV_ACTIVATE} && cd src && inv collect {state}")
 
 
 @task
-def lint(c):
+def lint(c):  # pylint: disable=invalid-name
   c.run(f"{VENV_ACTIVATE} && pylint tasks.py src --rcfile=.pylintrc")
 
 
 @task
-def lintwarn(c):
+def lintwarn(c):  # pylint: disable=invalid-name
   '''
   This is temporary and used to identify cases where certain warning flags are showing up
   Remove me when I no longer generate warnings.
@@ -25,5 +25,5 @@ def lintwarn(c):
 
 
 @task
-def test(c):
+def test(c):  # pylint: disable=invalid-name
   c.run(f"{VENV_ACTIVATE} && cd src && inv test")


### PR DESCRIPTION
- Fix `inv test` to use exit code > 0 if failure
- Enable duplicate_code, invalid_name
- Clean up all code to the additional lint tests
- Replace for loop iterator in minnesota with regex (inspired by lint fix)
- Remove lintwarn (no longer needed)